### PR TITLE
Add package.el dependency on polymode

### DIFF
--- a/tla-tools.el
+++ b/tla-tools.el
@@ -4,6 +4,7 @@
 
 ;; Author: Matt Curtis <matt.r.curtis@gmail.com>
 ;; Keywords: tools, languages
+;; Package-Requires: ((polymode "0.2.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
When installing this with `straight.el` the dependency on polymode was not automatically resolved. Adding this dependency to the package headers should benefit users of `package.el` and `straight.el`