### PR TITLE
Fix breakage with transient library API changes

### DIFF
--- a/tla-pcal-mode.el
+++ b/tla-pcal-mode.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2019  Matt Curtis
 
 ;; Author: Matt Curtis <matt.r.curtis@gmail.com>
+;; Version: 1.0
+;; Package-Requires: ((emacs "26.1") (polymode "0.2") (transient "0.3"))
 ;; Keywords: languages
+;; URL: https://github.com/mrc/tla-tools
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -455,7 +458,7 @@ be added to this command."
                (shell-quote-argument buffer-file-name)))
   (compile compile-command))
 
-(define-transient-command tla-pcal-transient ()
+(transient-define-prefix tla-pcal-transient ()
   "Menu of commands for TLA+ and PlusCal files."
   :value '("-shade")
   ["TLC Configuration"


### PR DESCRIPTION
Hi, transient is now a part of Emacs, but on the way it lost a function that I used.  Trivial fix attached; I also added some package metadata in case you want to add the mode to, e.g., the melpa package archive.