### PR TITLE
Highlight ternary expression in PlusCal

### DIFF
--- a/tla-pcal-mode.el
+++ b/tla-pcal-mode.el
@@ -95,7 +95,8 @@
        '("assert" "await" "begin" "call" "define" "do" "either"
          "else" "elsif" "end" "goto" "if" "macro" "or" "print"
          "procedure" "process" "return" "skip" "then" "variable"
-         "variables" "when" "while" "with" ":=" "||")
+         "variables" "when" "while" "with" ":=" "||" "IF" "THEN"
+         "ELSE")
        'symbols)
      . font-lock-keyword-face)
     (,(concat "\\bmacro\\S+\\(" pcal-mode--identifier-re "\\)\\((.*)\\)?\\S+begin")


### PR DESCRIPTION
It is a valid PlusCal to write a

    my_variable := IF foo THEN 7 ELSE 47;

so make sure to highlight IF-THEN-ELSE blocks as well.