### PR TITLE
Improve test coverage&prints by actually checking indentation

### DIFF
--- a/test/tla-pcal-mode-test.el
+++ b/test/tla-pcal-mode-test.el
@@ -73,10 +73,11 @@
         (insert line "\n"))
       (goto-char (point-min))
       (forward-line n) ; Add something in to place point at various places in line?
-      (let ((expected-indent (current-indentation)))
+      (let ((expected-indent (current-indentation))
+            (pcal-mode-indent-offset 2)
+            (indent-tabs-mode nil))
         (delete-horizontal-space)
-        (let* ((pcal-mode-indent-offset 2) ; dynamic binding because of defvar
-               (actual-indent (funcall indent-func))
+        (let* ((actual-indent (funcall indent-func))
                (exp-line (elt lines n)))
           ;; Add enough extra data to make clear where the failure happened
           (should (equal (list expected-indent (list 'line n) exp-line)

--- a/test/tla-pcal-mode-test.el
+++ b/test/tla-pcal-mode-test.el
@@ -73,13 +73,8 @@
         (insert line "\n"))
       (goto-char (point-min))
       (forward-line n) ; Add something in to place point at various places in line?
-      (let ((expected-indent 0))
-        (save-excursion
-          (beginning-of-line)
-          (skip-chars-forward " ")
-          (setq expected-indent (current-column))
-          (beginning-of-line)
-          (delete-horizontal-space))
+      (let ((expected-indent (current-indentation)))
+        (delete-horizontal-space)
         (let* ((pcal-mode-indent-offset 2) ; dynamic binding because of defvar
                (actual-indent (funcall indent-func))
                (exp-line (elt lines n)))

--- a/test/tla-pcal-mode-test.el
+++ b/test/tla-pcal-mode-test.el
@@ -53,8 +53,8 @@
   ;; in the test file
   (let ((lines (read-lines (test-file-path (concat test-name "." mode))))
         (indent-func (if (equal mode "pcal")
-                         #'pcal-mode--indent-column
-                       #'tla-mode--indent-column)))
+                         #'pcal-mode-indent-line
+                       #'tla-mode-indent-line)))
     (run-indent-test lines indent-func)))
 
 (ert-deftest pcal-mode--indent-column-test ()      (indent-test "indent-columns" "pcal"))
@@ -77,11 +77,15 @@
             (pcal-mode-indent-offset 2)
             (indent-tabs-mode nil))
         (delete-horizontal-space)
-        (let* ((actual-indent (funcall indent-func))
-               (exp-line (elt lines n)))
+        (funcall indent-func)
+        (let ((actual-indent (current-indentation))
+              (exp-line (elt lines n))
+              (actual-line (buffer-substring-no-properties
+                            (line-beginning-position)
+                            (line-end-position))))
           ;; Add enough extra data to make clear where the failure happened
           (should (equal (list expected-indent (list 'line n) exp-line)
-                         (list actual-indent (list 'line n) exp-line))))))))
+                         (list actual-indent (list 'line n) actual-line))))))))
 
 (ert-deftest tla-mode--keep-conjucts-indented ()
   (let ((test-lines

--- a/tla-pcal-mode.el
+++ b/tla-pcal-mode.el
@@ -176,11 +176,8 @@
 (defun tla-mode-indent-line ()
   "Indent the current line according to TLA+ rules."
   (interactive)
-  (save-excursion
-    (beginning-of-line)
-    (let ((col (tla-mode--indent-column)))
-      (when col
-        (indent-line-to col)))))
+  (when-let ((col (tla-mode--indent-column)))
+    (indent-line-to col)))
 
 (defcustom pcal-mode-indent-offset 2
   "Amount of columns to indent lines in PlusCal code."

--- a/tla-pcal-mode.el
+++ b/tla-pcal-mode.el
@@ -226,7 +226,7 @@
   ".*;"
   "Regexp for matching the end of a statement.")
 
-(defvar pcal-mode--statement-begin-re
+(defvar pcal-mode--variables-begin-re
   (concat "^[[:blank:]]*variables?\\>")
   "Regexp for matching the start of a statement.")
 
@@ -284,7 +284,7 @@ nil if the syntax isn't recognized for indentation."
                  (setq current (current-indentation)))
                 ((looking-at-p pcal-mode--statement-end-re)
                  (setq after-stmt t))
-                ((looking-at-p pcal-mode--statement-begin-re)
+                ((looking-at-p pcal-mode--variables-begin-re)
                  (if after-stmt
                      (setq current (current-indentation))
                    (setq current (+ (current-indentation) pcal-mode-indent-offset))))


### PR DESCRIPTION
The older code didn't test the public indentation function but instead some getter that the function was using. It also had a minor bug where the ELT's `should` function was given `exp-line` as part of the "actual" parameter.

We fix both problems and also do some minor cleanup.

--------------

This PR also includes a commit that changes `tla-mode-indent-line` to have code similar to commit fc1af6d250 for the other indentation function. When I did fc1af6d250 I didn't know there are two functions for the same functional. Feel free to ask me to send it as a separate PR if you want.