### PR TITLE
pcal-mode: improve code readability by shadowing labels

### DIFF
--- a/tla-pcal-mode.el
+++ b/tla-pcal-mode.el
@@ -90,6 +90,10 @@
     ,@tla-pcal-mode--shared-keywords
     ))
 
+(defface pcal-mode-label-face
+  '((t (:inherit shadow)))
+  "Face for PlusCal labels.")
+
 (defvar pcal-mode-font-lock-keywords
   `((,(regexp-opt
        '("assert" "await" "begin" "call" "define" "do" "either"
@@ -98,6 +102,8 @@
          "variables" "when" "while" "with" ":=" "||")
        'symbols)
      . font-lock-keyword-face)
+    (,(concat "^\\s-*\\(" pcal-mode--identifier-re ":\\)[^=]")
+     . '(1 'pcal-mode-label-face))
     (,(concat "\\bmacro\\S+\\(" pcal-mode--identifier-re "\\)\\((.*)\\)?\\S+begin")
      . '(1 font-lock-function-name-face))
     ,@tla-pcal-mode--shared-keywords))


### PR DESCRIPTION
PlusCal labels are mostly a necessity rather than part of the algorithm. They simply point places that can't execute atomically, which results in having them on almost every line. Labels are a hint to TLC much less to people reading the code. So let's have a separate face for labels that kind of shadows their visibility. There's a `shadow` face from which we inherit for that purpose.